### PR TITLE
fixes RSS logo path

### DIFF
--- a/assets/html_preamble.html
+++ b/assets/html_preamble.html
@@ -7,7 +7,7 @@
     <a href='/about.html' style='font-weight:bold; font-style:italic;'>About Me</a> /
     <a href='/photos.html' style='font-weight:bold; font-style:italic;'>Photos</a> /
     <a href='rss.xml'>
-      <img src='rss.png' style='height: 1em;'>
+      <img src='/rss.png' style='height: 1em;'>
     </a>
   </div>
 </div>


### PR DESCRIPTION
Previously the RSS logo wasn't rendering on subpages; switched to absolute path so it is now rendering correctly.